### PR TITLE
Don't require validation_run_ids in job list for Evaluation or Forecast

### DIFF
--- a/calibration/util/calibration_validators.py
+++ b/calibration/util/calibration_validators.py
@@ -386,7 +386,7 @@ class CalibrationJobsResponseSerializer(BaseSerializer):
     objective_function = serializers.CharField(required=False, allow_null=True)
     optimization_algorithm = serializers.CharField(required=False, allow_null=True)
     validation_runs = serializers.IntegerField(required=False)
-    validation_run_ids = serializers.ListSerializer(child=serializers.IntegerField())
+    validation_run_ids = serializers.ListSerializer(required=False,child=serializers.IntegerField())
     validations = serializers.ListSerializer(child=ValidationStatusSerializer(), required=False, allow_empty=True)
     modules = serializers.ListSerializer(child=serializers.CharField(required=True, allow_null=False, allow_blank=False), required=True)
     is_archived = serializers.BooleanField(required=True, allow_null=True)


### PR DESCRIPTION
Fix to get Forecast tab to load