### PR TITLE
Testing Dockerfile.production-pw and Building Images Again

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, nwm-main, development, release-candidate]
   push:
     branches: [main, nwm-main, development, release-candidate]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -55,6 +57,14 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            tag_suffix: ""
+          - dockerfile: Dockerfile.production-pw
+            tag_suffix: "-pw"
     steps:
       - uses: actions/checkout@v4
 
@@ -65,15 +75,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & push image
+      - name: Build & push (${{ matrix.dockerfile }}) image
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: true
-          tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}
+          tags: ${{ needs.setup.outputs.image_base }}:${{ needs.setup.outputs.test_image_tag }}${{ matrix.tag_suffix }}
           build-args: |
-            NGEN_FORCING_TAG=${{ env.NGEN_FORCING_TAG || 'development' }}
+            MSWM_ORG=${{ env.MSWM_ORG || 'NGWPC' }}
             MSWM_TAG=${{ env.MSWM_TAG || 'development' }}
+            NGEN_FORCING_ORG=${{ env.NGEN_FORCING_ORG || 'NGWPC' }}
+            NGEN_FORCING_TAG=${{ env.NGEN_FORCING_TAG || 'development' }}
+
 
   unit-test:
     name: unit-test
@@ -129,3 +143,93 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+
+  deploy-latest-on-development:
+    name: deploy-latest-on-development
+    if: github.event_name == 'push' && github.ref_name == 'development'
+    runs-on: ubuntu-latest
+    needs: [setup, build, unit-test, codeql-scan, container-scanning]
+    steps:
+      - name: Tag image with 'latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE_BASE="${{ needs.setup.outputs.image_base }}"
+
+          # get short sha tag for Dockerfile.production-pw
+          SHORT_SHA_PW="${{ needs.setup.outputs.commit_sha_short }}-pw"
+
+          # ensure skopeo is available
+          if ! command -v skopeo >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends skopeo
+          fi
+
+          skopeo copy \
+            --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            docker://"${IMAGE_BASE}:${SHORT_SHA_PW}" docker://"${IMAGE_BASE}:latest"
+
+  release:
+    name: release
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Get commit sha for the tag
+        id: rev
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          REPO="${{ github.repository }}"
+
+          # ensure jq is available
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends jq
+          fi
+
+          # ensure gh cli is available
+          if ! command -v gh >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends gh
+          fi
+
+          # get the commit sha for the tag
+          REF_JSON="$(gh api "repos/${REPO}/git/refs/tags/${TAG}")"
+          OBJ_SHA="$(jq -r '.object.sha' <<<"$REF_JSON")"
+          OBJ_TYPE="$(jq -r '.object.type' <<<"$REF_JSON")"
+
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            TAG_OBJ="$(gh api "repos/${REPO}/git/tags/${OBJ_SHA}")"
+            COMMIT_SHA="$(jq -r '.object.sha' <<<"$TAG_OBJ")"
+          else
+            COMMIT_SHA="$OBJ_SHA"
+          fi
+
+          # get short sha
+          SHORT_SHA="${COMMIT_SHA:0:12}"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag image with release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          IMAGE_BASE="${{ needs.setup.outputs.image_base }}"
+          # get short sha tag for Dockerfile.production-pw
+          SHORT_SHA_PW="${{ steps.rev.outputs.short_sha }}-pw"
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+
+          # ensure skopeo is available
+          if ! command -v skopeo >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends skopeo
+          fi
+
+          skopeo copy \
+            --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            docker://"${IMAGE_BASE}:${SHORT_SHA_PW}" docker://"${IMAGE_BASE}:${RELEASE_TAG}"

--- a/production-pw.yaml
+++ b/production-pw.yaml
@@ -9,7 +9,7 @@ services:
         - MSWM_TAG=${MSWM_TAG}
         - NGEN_FORCING_TAG=${NGEN_FORCING_TAG}
         - CACHE_BUST=${CACHE_BUST}
-    image: ghcr.io/ngwpc/ngencerf-server:prod
+    image: ghcr.io/ngwpc/ngencerf-server:${NGENCERF_SERVER_TAG:-latest}
     pull_policy: always
     ports:
       - "8000:8000"


### PR DESCRIPTION
- Now building Dockerfile.production-pw in addition to Dockerfile images
- Now pushing Dockerfile.production-pw images to ghcrc.io/ngwpc/ngencerf-server since Parallel Works builds now pull these images instead of building them on the cluster. Using `:latest` for merges to development and `:release tag` for official releases. 